### PR TITLE
Resolving artifact items as vars in the manifest

### DIFF
--- a/dx/artifact.go
+++ b/dx/artifact.go
@@ -44,3 +44,20 @@ func (a *Artifact) HasCleanupPolicy() bool {
 	}
 	return false
 }
+
+func (a *Artifact) Vars() map[string]string {
+	vars := map[string]string{}
+
+	for k, v := range a.Context {
+		vars[k] = v
+	}
+
+	for _, values := range a.Items {
+		for k, v := range values {
+			if w, ok := v.(string); ok {
+				vars[k] = w
+			}
+		}
+	}
+	return vars
+}

--- a/dx/artifact_test.go
+++ b/dx/artifact_test.go
@@ -1,0 +1,31 @@
+package dx
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_vars(t *testing.T) {
+	var a Artifact
+	json.Unmarshal([]byte(`
+{
+  "version": {},
+  "environments": [],
+  "context": {
+	"CI_VAR": "civalue"
+  },
+  "items": [
+    {
+      "name": "image",
+      "url": "nginx"
+    }
+  ]
+}
+`), &a)
+
+	vars := a.Vars()
+	assert.Equal(t, 3, len(vars))
+	assert.Equal(t, 1, len(a.Context))
+}

--- a/dx/manifest_test.go
+++ b/dx/manifest_test.go
@@ -1,8 +1,9 @@
 package dx
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_resolveVars(t *testing.T) {

--- a/worker/gitops.go
+++ b/worker/gitops.go
@@ -4,6 +4,11 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
 	"github.com/cenkalti/backoff/v4"
 	"github.com/gimlet-io/gimletd/dx"
 	"github.com/gimlet-io/gimletd/dx/helm"
@@ -19,10 +24,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
-	"os"
-	"path/filepath"
-	"strings"
-	"time"
 )
 
 type GitopsWorker struct {
@@ -271,7 +272,7 @@ func processReleaseEvent(
 		if env.Env != releaseRequest.Env {
 			continue
 		}
-		env.ResolveVars(artifact.Context)
+		env.ResolveVars(artifact.Vars())
 		if releaseRequest.App != "" &&
 			env.App != releaseRequest.App {
 			continue
@@ -469,7 +470,7 @@ func cloneTemplateWriteAndPush(
 		return gitopsEvent, err
 	}
 
-	err = env.ResolveVars(artifact.Context)
+	err = env.ResolveVars(artifact.Vars())
 	if err != nil {
 		err = fmt.Errorf("cannot resolve manifest vars %s", err.Error())
 		gitopsEvent.Status = events.Failure

--- a/worker/gitops_test.go
+++ b/worker/gitops_test.go
@@ -17,6 +17,10 @@ package worker
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
 	"github.com/gimlet-io/gimletd/dx"
 	"github.com/gimlet-io/gimletd/git/nativeGit"
 	"github.com/go-git/go-billy/v5/memfs"
@@ -26,9 +30,6 @@ import (
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
-	"io/ioutil"
-	"os"
-	"testing"
 )
 
 func Test_gitopsTemplateAndWrite(t *testing.T) {
@@ -533,8 +534,8 @@ func Test_cleanupTrigger(t *testing.T) {
 	assert.False(t, triggered, "Should not trigger on missing branch filter")
 
 	triggered = cleanupTrigger("preview-test", &dx.Cleanup{
-		Branch:       "preview-test",
-		Event:        dx.BranchDeleted,
+		Branch: "preview-test",
+		Event:  dx.BranchDeleted,
 	})
 	assert.False(t, triggered, "Should not trigger on missing app")
 }


### PR DESCRIPTION
You can pass distinguished metadata in the artifact as an item:

```
./gimlet artifact add \
  -f artifact.json \
  --field "image=mycompany/myapp:v123"
```

then you can reference it in the Gimlet manifest as

```
{{ .image }}
```